### PR TITLE
Generator: Write packet sizes from file sizes

### DIFF
--- a/use-cases/corporate-iodine.json
+++ b/use-cases/corporate-iodine.json
@@ -28,6 +28,8 @@
         "module" : "simplex",
         "send_app_address" : "Alice",
         "send_app_queue_pkt_sizes" : [200, 200, 100, 10],
+        "file_size_bytes" : 510,
+        "max_pkt_payload_size_bytes" : 167,
         "app_start_send_time" : 1.0,
         "rcv_app_address" : "Bob",
         "include_dns_client" : false


### PR DESCRIPTION
To verify:
* Look at the code changes.
* Run a prob generation.  If the packet sizes are specified in the use-case, they are used.  Otherwise, if [] or not specified, they are automatically computed from file size and max packet size.  (that way, we can create richer scenarios for test)

=====================================================================
Write the packet sizes from file size and maximum packet size.  The supposed header size is 33B.

If the packet sizes are explicitly specified, then they are used and this computation does not take place.