### PR TITLE
Iodine: Specify high end for application pacing

### DIFF
--- a/maude_hcs/lib/dns/maude/probabilistic/iodine_dns.maude
+++ b/maude_hcs/lib/dns/maude/probabilistic/iodine_dns.maude
@@ -160,7 +160,7 @@ crl [wnameserver-receive-query-weird]:
   =>
     < ALICE : SendApp | appAttrsNext >
     (if msgOut == nullMsg then null else [0.0, msgOut, 0] fi)
-    (if msgOut == nullMsg then null else [pacingTimeoutDelay, (to ALICE : pktTimeout(getPkt(msgOut))), 0] fi)
+    (if msgOut == nullMsg then null else [sampleUniform(pacingTimeoutDelay, pacingTimeoutDelayMax), (to ALICE : pktTimeout(getPkt(msgOut))), 0] fi)
     *** Start means that the client is ready.
     if appAttrs1 := (appAttrs, wclientReady: true)
     /\ {appAttrsNext, msgOut} :=
@@ -182,7 +182,7 @@ crl [wnameserver-receive-query-weird]:
   =>
     < ALICE : SendApp | appAttrsNext >
     (if msgOut == nullMsg then null else [0.0, msgOut, 0] fi)
-    (if msgOut == nullMsg then null else [pacingTimeoutDelay, (to ALICE : pktTimeout(getPkt(msgOut))), 0] fi)
+    (if msgOut == nullMsg then null else [sampleUniform(pacingTimeoutDelay, pacingTimeoutDelayMax), (to ALICE : pktTimeout(getPkt(msgOut))), 0] fi)
     *** Timeout means it is OK to send a packet now.
     if appAttrs1 := (appAttrs, numAdmittedPkts: s N)
       /\ {appAttrsNext, msgOut} := 

--- a/maude_hcs/lib/dns/maude/probabilistic/parameters.maude
+++ b/maude_hcs/lib/dns/maude/probabilistic/parameters.maude
@@ -37,7 +37,9 @@ mod IODINE-PARAMETERS is
 
   *** Send App packet packing delay
   op pacingTimeoutDelay : -> Float .
-  eq pacingTimeoutDelay = 0.505 .
+
+  *** Send App packet spacing delay (max value)
+  op pacingTimeoutDelayMax : -> Float .
 
   *** IodineServer last fragment delay
   op lastFragDelay : -> Float .

--- a/use-cases/corporate-iodine.json
+++ b/use-cases/corporate-iodine.json
@@ -8,6 +8,7 @@
     "probabilistic_parameters" : {
         "nsResourceBounds?" : false,
         "pacingTimeoutDelay" : 0.05,
+        "pacingTimeoutDelayMax" : 0.07,
         "ackTimeoutDelay" : 1.0
     },
     "underlying_network": {


### PR DESCRIPTION
Specify high end pacingDelayMax for application pacing.  The delay is uniform between pacingDelay and pacingDelayMax.

(full disclosure: I have not tested this branch much, but I think it is necessary for the work we are doing with extracting the shadow values to match to our model; it will be more thoroughly tested at that time)
To verify:
* Inspect code changes.
* Grab same branch from DNS-formalization.
* Generate and run a probabilistic experiment (should not have changed anything).