### PR TITLE
Fix 0-byte HTTP request bug in Mastodon model

### DIFF
--- a/maude_hcs/lib/mastodon/maude/common/_aux.maude
+++ b/maude_hcs/lib/mastodon/maude/common/_aux.maude
@@ -130,8 +130,8 @@ mod MASTODON_NODE is
   --- 448 bytes is a fixed proxy for the size of HTTP GET headers (Host, User-Agent, etc.).
   eq getSize(makeHttpRequest(getRequest, URL)) = 448 .
   eq getSize(makeHttpRequest(getRequest, POST_ID)) = 448 .
-  eq getSize(makeHttpRequest(getRequest, TAG)) = 448 .
-  eq getSize(makeHttpRequest(getRequest, TAG, LIMIT)) = 448 .
+  eq getSize(makeHttpRequest(getRequest, TAG)) = 448 + getSize(TAG) .
+  eq getSize(makeHttpRequest(getRequest, TAG, LIMIT)) = 448 + getSize(TAG) .
   eq getSize(makeHttpRequest(getRequest)) = 448 .
 
   op getSize : HttpResponse -> Nat .

--- a/maude_hcs/lib/mastodon/maude/common/_aux.maude
+++ b/maude_hcs/lib/mastodon/maude/common/_aux.maude
@@ -127,12 +127,18 @@ mod MASTODON_NODE is
   eq getSize(makeHttpRequest(postRequest, MEDIA_FILE)) = 448 + getSize(MEDIA_FILE) .
   eq getSize(makeHttpRequest(postRequest, POST_TEXT, MAS_ID_LIST)) = 448 + length(POST_TEXT) .
   eq getSize(makeHttpRequest(postRequest, POST_TEXT)) = 448 + length(POST_TEXT) .
-  eq getSize(HTTP_REQUEST) = 448 [owise] .
+  --- 448 bytes is a fixed proxy for the size of HTTP GET headers (Host, User-Agent, etc.).
+  eq getSize(makeHttpRequest(getRequest, URL)) = 448 .
+  eq getSize(makeHttpRequest(getRequest, POST_ID)) = 448 .
+  eq getSize(makeHttpRequest(getRequest, TAG)) = 448 .
+  eq getSize(makeHttpRequest(getRequest, TAG, LIMIT)) = 448 .
+  eq getSize(makeHttpRequest(getRequest)) = 448 .
 
   op getSize : HttpResponse -> Nat .
   eq getSize(makeHttpResponse(STATUS, MEDIA_FILE)) = 448 + getSize(MEDIA_FILE) .
   eq getSize(makeHttpResponse(STATUS, RESPONSE_TOOT_LIST)) = 448 .
-  eq getSize(HTTP_RESPONSE) = 448 [owise] .
+  --- Explicitly define getSize for a simple status response (e.g. errors).
+  eq getSize(makeHttpResponse(STATUS)) = 448 .
 
   vars httpMsg HTTP_MSG : HttpMsg .
   vars httpRequest HTTP_REQUEST : HttpRequest .

--- a/maude_hcs/lib/mastodon/maude/common/tag.maude
+++ b/maude_hcs/lib/mastodon/maude/common/tag.maude
@@ -44,6 +44,10 @@ mod TAGS is
   op makeTag : String -> Tag .
   op nilTag : -> Tag .
 
+  op getSize : Tag -> Nat .
+  eq getSize(makeTag(S:String)) = length(S:String) .
+  eq getSize(nilTag) = 0 .
+
   op emptyTagList : -> TagList [ctor] .
   op _;;_ : TagList TagList -> TagList [ctor assoc id: emptyTagList] .
 


### PR DESCRIPTION
* Remove broken `[owise]` fallbacks for HTTP_REQUEST and HTTP_RESPONSE sizes.

* Explicitly define `getSize` for all 5 `GetRequest` constructors and error responses.

* Assigns 448 bytes to model HTTP header overhead, preventing GET requests from silently falling back to a 0-byte transmission size in the network model.